### PR TITLE
Allow parameters to be declared, not used

### DIFF
--- a/src/base/ver/verCore.c
+++ b/src/base/ver/verCore.c
@@ -454,6 +454,14 @@ int Ver_ParseModule( Ver_Man_t * pMan )
             RetValue = Ver_ParseSignal( pMan, pNtk, VER_SIG_WIRE );
         else if ( !strcmp( pWord, "inout" ) )
             RetValue = Ver_ParseSignal( pMan, pNtk, VER_SIG_INOUT );
+	// If there is a parameter declared here
+        else if ( !strcmp( pWord, "parameter" ) )
+        {
+            printf("%s (line %d): ", Ver_StreamGetFileName(p), Ver_StreamGetLineNumber(p));
+            printf("Parametrization is not supported, and parameters will be ignored.\n");
+            // skip till the end of line
+            Ver_StreamSkipToChars( p, "\n" );
+        }
         else 
             break;
         if ( RetValue == 0 )


### PR DESCRIPTION
I added some code on line 457 of verCore.c to print a warning about parameter instantiation, but allowing the parsing to continue rather than stop.
This way, parameters can be declared, although they are not supported in the rest of the code.
The reason to do this is that I need to declare a "variable" inside verilog module for a project of mine, and instead of putting it in a comment (which could be removed/overlooked by other tools) I thought I could use parameters. ABC is part of my flow, and when I realized that simply declaring a parameter that was not used in the rest of the module prevented ABC from reading a verilog file, I changed the code to make some wiggle room.

I apologize if the diff looks complicated: I only added 8 lines of code, but the EOL characters changed and so it looks like I changed a lot more.